### PR TITLE
docs: add CLAUDE.md with project overview and development guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# JHighlight
+
+Embeddable pure Java syntax highlighting library (Java, Groovy, JS, C++, XML, HTML).
+Fork of original jhighlight with multi-byte character fixes.
+
+## Commands
+
+```bash
+mvn clean install        # Build and install
+mvn test                 # Run tests
+mvn jacoco:report        # Generate coverage report (target/site/jacoco/)
+```
+
+## Architecture
+
+```
+src/main/java/
+  org/codelibs/jhighlight/
+    highlighter/          # Language-specific syntax highlighters
+    renderer/             # XHTML output renderers (XhtmlRenderer, XhtmlRendererFactory)
+    servlet/              # HighlightFilter for web integration
+    tools/                # StringUtils, FileUtils, ExceptionUtils
+    fastutil/             # Inlined fastutil data structures (chars, ints, objects)
+  com/uwyn/jhighlight/    # Legacy package (backward compatibility)
+```
+
+## Gotchas
+
+- Dual package structure: `org.codelibs.jhighlight` (preferred) and `com.uwyn.jhighlight` (legacy compat)
+- Java 8 source/target level despite modern Maven plugins
+- `fastutil/` is inlined (not a dependency) - do not add fastutil as a Maven dependency
+- Servlet API is `provided` scope (2.3) - only available at compile time
+- Release uses maven-release-plugin + GPG signing + Sonatype Central publishing


### PR DESCRIPTION
## Summary
Add a CLAUDE.md file to provide project context, build commands, architecture overview, and important gotchas for AI-assisted development.

## Changes Made
- Added `CLAUDE.md` with:
  - Project description and purpose
  - Build and test commands (`mvn clean install`, `mvn test`, `mvn jacoco:report`)
  - Source tree architecture overview
  - Key gotchas (dual package structure, inlined fastutil, servlet API scope, Java 8 target, release process)

## Testing
- Documentation only; no code changes

## Additional Notes
- This file helps AI coding assistants understand the project structure and avoid common pitfalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)