### PR TITLE
build: bump maven plugins and move gpg signing to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<source>17</source>
 					<target>17</target>
@@ -65,7 +65,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.5.5</version>
 				<configuration>
 					<includes>
 						<include>**/*Test.java</include>
@@ -76,7 +76,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.12.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -106,7 +106,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.4.2</version>
+				<version>3.5.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -116,23 +116,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.10.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
@@ -140,11 +126,37 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.19.0</version>
+			<version>2.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
## Summary
Update Maven build plugins and `commons-io` to current versions, and move `maven-gpg-plugin` into a dedicated `release` profile so artifact signing only runs when explicitly releasing.

## Changes Made
- Bump `maven-compiler-plugin` 3.14.0 → 3.15.0
- Bump `maven-surefire-plugin` 3.5.0 → 3.5.5
- Bump `jacoco-maven-plugin` 0.8.13 → 0.8.14
- Bump `maven-javadoc-plugin` 3.11.2 → 3.12.0
- Bump `maven-jar-plugin` 3.4.2 → 3.5.0
- Bump `central-publishing-maven-plugin` 0.7.0 → 0.10.0
- Bump `commons-io` 2.19.0 → 2.22.0
- Move `maven-gpg-plugin` (bumped to 3.2.8) out of the default build into a new `release` profile, with `bestPractices` enabled

## Testing
- Local build (`mvn clean install`) — non-release builds no longer require a GPG key.
- Release builds should be triggered with `-Prelease` so the GPG signing execution runs as before.

## Breaking Changes
- None for library consumers. Release tooling must now activate the `release` profile (e.g., `mvn -Prelease ...`) to produce signed artifacts; this should already match how `maven-release-plugin` is invoked, but worth verifying in CI/release scripts.

## Additional Notes
- The `bestPractices` GPG flag opts into the modern signing workflow recommended by the plugin (no passphrase on the command line, subkey usage, etc.).