### PR TITLE
build: move release-only plugins to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,39 +93,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.12.0</version>
-				<configuration>
-					<encoding>UTF-8</encoding>
-					<docencoding>UTF-8</docencoding>
-					<charset>UTF-8</charset>
-					<source>17</source>
-					<doclint>none</doclint>
-				</configuration>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.5.0</version>
 				<configuration>
@@ -134,6 +101,13 @@
 							<Automatic-Module-Name>org.codelibs.jhighlight</Automatic-Module-Name>
 						</manifestEntries>
 					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>3.1.1</version>
+				<configuration>
+					<releaseProfiles>release</releaseProfiles>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -152,6 +126,39 @@
 			<id>release</id>
 			<build>
 				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>3.3.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>3.12.0</version>
+						<configuration>
+							<encoding>UTF-8</encoding>
+							<docencoding>UTF-8</docencoding>
+							<charset>UTF-8</charset>
+							<source>17</source>
+							<doclint>none</doclint>
+						</configuration>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
## Summary
Standardize the release configuration following the maven-release-plugin 2→3 migration guide (https://maven.apache.org/maven-release/maven-release-plugin/migrate.html): release-only plugins now live in the `release` profile, which maven-release-plugin activates automatically during `release:perform`.

## Changes Made
- Moved maven-source-plugin (`attach-sources`) and maven-javadoc-plugin (`attach-javadocs`) from the main build into the existing `release` profile, alongside maven-gpg-plugin
- Added maven-release-plugin 3.1.1 with `<releaseProfiles>release</releaseProfiles>`

## Testing
- `mvn package -DskipTests` — no sources/javadoc jars produced, no GPG required for local builds
- `mvn package -P release -DskipTests -Dgpg.skip=true` — sources and javadoc jars are produced

## Additional Notes
- Plain `mvn install` no longer attaches sources/javadoc jars locally; they are generated only during releases.
- Same pattern as codelibs/fesen-httpclient; applied across CodeLibs repositories for consistency.